### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,7 @@
                     <includes>
                         <include>**/*Tests.java</include>
                     </includes>
+		    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
we need that configuration because without it, at the moment of running the program it marks an error

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 20.037 s
[INFO] Finished at: 2018-11-11T13:30:33-07:00
[INFO] Final Memory: 77M/221M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.0:test (default-test) on project spring-petclinic: There are test failures.
[ERROR]
[ERROR] Please refer to /home/joshuansu0897/spring-framework-petclinic/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /home/joshuansu0897/spring-framework-petclinic && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -javaagent:/home/joshuansu0897/.m2/repository/org/jacoco/org.jacoco.agent/0.8.1/org.jacoco.agent-0.8.1-runtime.jar=destfile=/home/joshuansu0897/spring-framework-petclinic/target/jacoco.exec -jar /home/joshuansu0897/spring-framework-petclinic/target/surefire/surefirebooter3667402705000973217.jar /home/joshuansu0897/spring-framework-petclinic/target/surefire 2018-11-11T13-30-32_287-jvmRun1 surefire7664207262816689567tmp surefire_07973211666885987068tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 1
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /home/joshuansu0897/spring-framework-petclinic && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -javaagent:/home/joshuansu0897/.m2/repository/org/jacoco/org.jacoco.agent/0.8.1/org.jacoco.agent-0.8.1-runtime.jar=destfile=/home/joshuansu0897/spring-framework-petclinic/target/jacoco.exec -jar /home/joshuansu0897/spring-framework-petclinic/target/surefire/surefirebooter3667402705000973217.jar /home/joshuansu0897/spring-framework-petclinic/target/surefire 2018-11-11T13-30-32_287-jvmRun1 surefire7664207262816689567tmp surefire_07973211666885987068tmp
[ERROR] Error occurred in starting fork, check output in log
```

```
cat ./pring-framework-petclinic/target/surefire-reports/2018-11-11T13-30-33_427.dumpstream
# Created at 2018-11-11T13:30:33.428
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter
```