### PR TITLE
Update Maven Enforcer Plugin version to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
         <jacoco-maven-plugin>0.8.15</jacoco-maven-plugin>
-        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <libsass-maven-plugin.version>0.3.4</libsass-maven-plugin.version>
 
         <!-- Docker image -->


### PR DESCRIPTION
This is a narrowly scoped dependency/plugin maintenance candidate.

## Change

- `maven-enforcer-plugin.version`: `3.6.2` -> `3.6.3`

## Local validation

- `mvn test`: pass
- `mvn verify`: pass

## Scope

Changed file:

- `pom.xml`

## Boundaries

- This PR does not claim a security fix.
- This PR does not claim deployment readiness.
- This PR does not claim product readiness.
- This PR does not imply maintainer approval.
- This PR does not imply merge approval.
- Maintainer review is required.

## Context

This PR comes from a bounded, human-authorized local patch-candidate workflow. The patch is intentionally small and limited to a Maven plugin version update.
